### PR TITLE
Fixed letter for Italian Translation

### DIFF
--- a/PlayerConnectionMessage/media/lua/shared/Translate/IT/IG_UI_IT.txt
+++ b/PlayerConnectionMessage/media/lua/shared/Translate/IT/IG_UI_IT.txt
@@ -1,8 +1,8 @@
 IGUI_IT = {
     
-    IGUI_PlayerConnectionMessage_Connected = "%1 si è unito.",
-    IGUI_PlayerConnectionMessage_Disconnected = "%1 è uscito.",
-    IGUI_PlayerConnectionMessage_Killed = "%2 è stato ucciso da %1",
-    IGUI_PlayerConnectionMessage_Died = "%1 è morto.",
+    IGUI_PlayerConnectionMessage_Connected = "%1 si e' unito.",
+    IGUI_PlayerConnectionMessage_Disconnected = "%1 e' uscito.",
+    IGUI_PlayerConnectionMessage_Killed = "%2 e' stato ucciso da %1",
+    IGUI_PlayerConnectionMessage_Died = "%1 e' morto.",
 
 }


### PR DESCRIPTION
Changed the "è" with "e'" cause in output create a letter issue. 